### PR TITLE
Initial commit

### DIFF
--- a/es.yaml
+++ b/es.yaml
@@ -1,4 +1,8 @@
-# A headless service to create DNS records
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: elasticsearch
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,13 +21,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: elasticsearch_cluster
+  name: elasticsearch-cluster
   labels:
-    app: elasticsearch_cluster
+    app: elasticsearch-cluster
 spec:
   ports:
   - port: 9300
-    name: cluster_comms
+    name: cluster-comms
   clusterIP: None
   selector:
     app: elasticsearch
@@ -48,41 +52,39 @@ spec:
         image: quay.io/samsung_cnct/elasticsearch:0.1
         ports:
         - containerPort: 9300
+        resources:
+          limits:
+            cpu: 200m
+            memory: 4Gi
+          requests:
+            cpu: 200m
+            memory: 4Gi
         env:
         - name: CLUSTER_NAME
           value: "k8s-production"
         - name: NODE_DATA
-          value: false
+          value: "false"
         - name: NODE_MASTER
-          value: true
+          value: "true"
         - name: SERVICE
-          value: elasticsearch_cluster
-        - name: NAMESPACE
+          value: "elasticsearch-cluster"
+        - name: ES_JAVA_OPTS
+          value: "-Xms2g -Xmx2g -Djava.net.preferIPv4Stack=true"
+        - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
-              fieldPath: metadata.NAMESPACE
+              fieldPath: metadata.namespace
         - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
         imagePullPolicy: Always
         volumeMounts:
-        - name: datadir
-          mountPath: /mnt/elasticsearch/data
-        - name: logsdis
-          mountPath: /mnt/elasticsearch/logs 
+        - name: esdata
+          mountPath: /usr/share/elasticsearch/data
   volumeClaimTemplates:
   - metadata:
-      name: datadir
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 20Gi
-  - metadata:
-      name: logsdir
+      name: esdata
       annotations:
         volume.alpha.kubernetes.io/storage-class: anything
     spec:
@@ -111,41 +113,40 @@ spec:
         image: quay.io/samsung_cnct/elasticsearch:0.1
         ports:
         - containerPort: 9300
+        - containerPort: 9200
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 4Gi
+          requests:
+            cpu: 500m
+            memory: 4Gi
         env:
         - name: CLUSTER_NAME
           value: "k8s-production"
         - name: NODE_DATA
-          value: true
+          value: "true"
         - name: NODE_MASTER
-          value: false
+          value: "false"
         - name: SERVICE
-          value: elasticsearch_cluster
-        - name: NAMESPACE
+          value: "elasticsearch-cluster"
+        - name: ES_JAVA_OPTS
+          value: "-Xms2g -Xmx2g -Djava.net.preferIPv4Stack=true"
+        - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
-              fieldPath: metadata.NAMESPACE
+              fieldPath: metadata.namespace
         - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
         imagePullPolicy: Always
         volumeMounts:
-        - name: datadir
-          mountPath: /mnt/elasticsearch/data
-        - name: logsdis
-          mountPath: /mnt/elasticsearch/logs 
+        - name: esdata
+          mountPath: /usr/share/elasticsearch/data
   volumeClaimTemplates:
   - metadata:
-      name: datadir
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 20Gi
-  - metadata:
-      name: logsdir
+      name: esdata
       annotations:
         volume.alpha.kubernetes.io/storage-class: anything
     spec:

--- a/es.yaml
+++ b/es.yaml
@@ -1,0 +1,155 @@
+# A headless service to create DNS records
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  labels:
+    app: elasticsearch
+spec:
+  ports:
+  - port: 9200
+    name: http
+  clusterIP: None
+  selector:
+    name: elasticsearch-data
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch_cluster
+  labels:
+    app: elasticsearch_cluster
+spec:
+  ports:
+  - port: 9300
+    name: cluster_comms
+  clusterIP: None
+  selector:
+    app: elasticsearch
+---
+apiVersion: apps/v1alpha1
+kind: PetSet
+metadata:
+  name: elasticsearch-master
+spec:
+  serviceName: "elasticsearch-master"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+        name: elasticsearch-master
+      annotations:
+        pod.alpha.kubernetes.io/initialized: "true"
+    spec:
+      containers:
+      - name: elasticsearch
+        image: quay.io/samsung_cnct/elasticsearch:0.1
+        ports:
+        - containerPort: 9300
+        env:
+        - name: CLUSTER_NAME
+          value: "k8s-production"
+        - name: NODE_DATA
+          value: false
+        - name: NODE_MASTER
+          value: true
+        - name: SERVICE
+          value: elasticsearch_cluster
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.NAMESPACE
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: datadir
+          mountPath: /mnt/elasticsearch/data
+        - name: logsdis
+          mountPath: /mnt/elasticsearch/logs 
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+      annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 20Gi
+  - metadata:
+      name: logsdir
+      annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 20Gi
+---
+apiVersion: apps/v1alpha1
+kind: PetSet
+metadata:
+  name: elasticsearch-data
+spec:
+  serviceName: "elasticsearch-data"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+        name: elasticsearch-data
+      annotations:
+        pod.alpha.kubernetes.io/initialized: "true"
+    spec:
+      containers:
+      - name: elasticsearch
+        image: quay.io/samsung_cnct/elasticsearch:0.1
+        ports:
+        - containerPort: 9300
+        env:
+        - name: CLUSTER_NAME
+          value: "k8s-production"
+        - name: NODE_DATA
+          value: true
+        - name: NODE_MASTER
+          value: false
+        - name: SERVICE
+          value: elasticsearch_cluster
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.NAMESPACE
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: datadir
+          mountPath: /mnt/elasticsearch/data
+        - name: logsdis
+          mountPath: /mnt/elasticsearch/logs 
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+      annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 20Gi
+  - metadata:
+      name: logsdir
+      annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 20Gi

--- a/es.yaml
+++ b/es.yaml
@@ -16,7 +16,6 @@ spec:
   clusterIP: None
   selector:
     name: elasticsearch-data
-  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service
@@ -46,7 +45,21 @@ spec:
         name: elasticsearch-master
       annotations:
         pod.alpha.kubernetes.io/initialized: "true"
+        pod.alpha.kubernetes.io/init-containers: '[
+            {
+                "name": "max-map-count-set",
+                "image": "quay.io/samsung_cnct/set_max_map_count:1.1",
+                "imagePullPolicy": "Always",
+                "volumeMounts": [
+                    {
+                        "name": "hostproc",
+                        "mountPath": "/hostproc"
+                    }
+                ]
+            }]'
     spec:
+      serviceAccount: elasticsearch
+      serviceAccountName: elasticsearch
       containers:
       - name: elasticsearch
         image: quay.io/samsung_cnct/elasticsearch:0.1
@@ -54,10 +67,10 @@ spec:
         - containerPort: 9300
         resources:
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 4Gi
           requests:
-            cpu: 200m
+            cpu: 500m
             memory: 4Gi
         env:
         - name: CLUSTER_NAME
@@ -69,7 +82,7 @@ spec:
         - name: SERVICE
           value: "elasticsearch-cluster"
         - name: ES_JAVA_OPTS
-          value: "-Xms2g -Xmx2g -Djava.net.preferIPv4Stack=true"
+          value: "-Xms3g -Xmx3g -Djava.net.preferIPv4Stack=true"
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
@@ -82,6 +95,10 @@ spec:
         volumeMounts:
         - name: esdata
           mountPath: /usr/share/elasticsearch/data
+      volumes:
+      - name: hostproc
+        hostPath: 
+          path: /proc
   volumeClaimTemplates:
   - metadata:
       name: esdata
@@ -107,7 +124,21 @@ spec:
         name: elasticsearch-data
       annotations:
         pod.alpha.kubernetes.io/initialized: "true"
+        pod.alpha.kubernetes.io/init-containers: '[
+            {
+                "name": "max-map-count-set",
+                "image": "quay.io/samsung_cnct/set_max_map_count:1.1",
+                "imagePullPolicy": "Always",
+                "volumeMounts": [
+                    {
+                        "name": "hostproc",
+                        "mountPath": "/hostproc"
+                    }
+                ]
+            }]'
     spec:
+      serviceAccount: elasticsearch
+      serviceAccountName: elasticsearch
       containers:
       - name: elasticsearch
         image: quay.io/samsung_cnct/elasticsearch:0.1
@@ -116,7 +147,7 @@ spec:
         - containerPort: 9200
         resources:
           limits:
-            cpu: 1000m
+            cpu: 500m
             memory: 4Gi
           requests:
             cpu: 500m
@@ -131,7 +162,7 @@ spec:
         - name: SERVICE
           value: "elasticsearch-cluster"
         - name: ES_JAVA_OPTS
-          value: "-Xms2g -Xmx2g -Djava.net.preferIPv4Stack=true"
+          value: "-Xms3g -Xmx3g -Djava.net.preferIPv4Stack=true"
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
@@ -144,6 +175,10 @@ spec:
         volumeMounts:
         - name: esdata
           mountPath: /usr/share/elasticsearch/data
+      volumes:
+      - name: hostproc
+        hostPath: 
+          path: /proc
   volumeClaimTemplates:
   - metadata:
       name: esdata

--- a/es.yaml
+++ b/es.yaml
@@ -49,7 +49,6 @@ spec:
             {
                 "name": "max-map-count-set",
                 "image": "quay.io/samsung_cnct/set_max_map_count:1.1",
-                "imagePullPolicy": "Always",
                 "volumeMounts": [
                     {
                         "name": "hostproc",
@@ -64,7 +63,9 @@ spec:
       - name: elasticsearch
         image: quay.io/samsung_cnct/elasticsearch:0.1
         ports:
-        - containerPort: 9300
+        - name: cluster-comms 
+          containerPort: 9300
+        #  resource notes:  master is light weight so half a CPU.  Less then 4GB causes the container to OOM
         resources:
           limits:
             cpu: 500m
@@ -74,13 +75,14 @@ spec:
             memory: 4Gi
         env:
         - name: CLUSTER_NAME
-          value: "k8s-production"
+          value: "elasticsearch-cluster"
         - name: NODE_DATA
           value: "false"
         - name: NODE_MASTER
           value: "true"
         - name: SERVICE
           value: "elasticsearch-cluster"
+        #  the min/max *must* be the same due to elasticsearch 5.0 bootstrap checks
         - name: ES_JAVA_OPTS
           value: "-Xms3g -Xmx3g -Djava.net.preferIPv4Stack=true"
         - name: KUBERNETES_NAMESPACE
@@ -108,6 +110,7 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
+          #  set to small so when exploring with this the user doesn't accidentally create very large disks
           storage: 20Gi
 ---
 apiVersion: apps/v1alpha1
@@ -128,7 +131,6 @@ spec:
             {
                 "name": "max-map-count-set",
                 "image": "quay.io/samsung_cnct/set_max_map_count:1.1",
-                "imagePullPolicy": "Always",
                 "volumeMounts": [
                     {
                         "name": "hostproc",
@@ -143,8 +145,12 @@ spec:
       - name: elasticsearch
         image: quay.io/samsung_cnct/elasticsearch:0.1
         ports:
-        - containerPort: 9300
-        - containerPort: 9200
+        - name: cluster-comms
+          containerPort: 9300
+        - name: http
+          containerPort: 9200
+        #  resource notes:  datanodes are pretty heavy.  These should be modified up for a real production setting
+        #  recommendation is two cores and 20GB of memory for the containers
         resources:
           limits:
             cpu: 500m
@@ -154,13 +160,15 @@ spec:
             memory: 4Gi
         env:
         - name: CLUSTER_NAME
-          value: "k8s-production"
+          value: "elasticsearch-cluster"
         - name: NODE_DATA
           value: "true"
         - name: NODE_MASTER
           value: "false"
         - name: SERVICE
           value: "elasticsearch-cluster"
+        #  the min/max *must* be the same due to elasticsearch 5.0 bootstrap checks.  For a production settings
+        #  this should be 16GB.  Don't go over 32GB as the JVM starts to have issues.
         - name: ES_JAVA_OPTS
           value: "-Xms3g -Xmx3g -Djava.net.preferIPv4Stack=true"
         - name: KUBERNETES_NAMESPACE
@@ -188,4 +196,5 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
+          #  set to small so when exploring with this the user doesn't accidentally create very large disks
           storage: 20Gi

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -16,6 +16,4 @@ FROM elasticsearch:5.0
 
 RUN bin/elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:5.0.0
 
-ENV JAVA_OPTS=-Djava.net.preferIPv4Stack=true
-
 ADD elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2016 Samsung SDS Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM elasticsearch:5.0
+
+RUN bin/elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:5.0.0
+
+ENV JAVA_OPTS=-Djava.net.preferIPv4Stack=true
+
+ADD elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml

--- a/init/Makefile
+++ b/init/Makefile
@@ -1,0 +1,27 @@
+# Copyright 2016 Samsung SDS Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+all: push
+
+TAG = 0.1
+PREFIX = quay.io/samsung_cnct/elasticsearch
+
+container:
+	docker build -t $(PREFIX):$(TAG) .
+
+push: container
+	docker push $(PREFIX):$(TAG)
+
+clean:
+	docker rmi $(PREFIX):$(TAG)

--- a/init/elasticsearch.yml
+++ b/init/elasticsearch.yml
@@ -23,6 +23,5 @@ discovery:
     minimum_master_nodes: 2
     
 path:
-  plugins: /usr/share/elasticsearch/plugins
-  data: /mnt/elasticsearch/data
-  logs: /mnt/elasticsearch/logs
+  data: /usr/share/elasticsearch/data
+  logs: /usr/share/elasticsearch/logs

--- a/init/elasticsearch.yml
+++ b/init/elasticsearch.yml
@@ -1,0 +1,28 @@
+cluster.name: ${CLUSTER_NAME}
+network.host: 0.0.0.0
+
+node: 
+  data: ${NODE_DATA}
+  master: ${NODE_MASTER}
+  name: ${NODE_NAME}
+  ingest: false
+
+cloud:
+  kubernetes:
+    service: ${SERVICE}
+    namespace: ${KUBERNETES_NAMESPACE}
+
+gateway:
+  #recover_after_nodes: 70-80% of running nodes
+  #expected_nodes: total number of nodes
+  recover_after_time: 5m
+
+discovery:
+  type: kubernetes
+  zen:
+    minimum_master_nodes: 2
+    
+path:
+  plugins: /usr/share/elasticsearch/plugins
+  data: /mnt/elasticsearch/data
+  logs: /mnt/elasticsearch/logs


### PR DESCRIPTION
this will create an elasticsearch cluster with 3 master nodes and 3 data nodes.  it also creates two services:  one which is cluster wide on port 9300 and one which only connects to the data nodes on 9200.  the master nodes should not be serving up anything on 9200 so don't let them.

full details for why this is the setup can be found in the design story:  ADA-5